### PR TITLE
Docs: fix typo in README dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Add the dependent repository GraphUtil with the command `add https://github.com/
 ```Julia
 pkg> add https://github.com/sisl/GraphUtils.jl.git
 ```
-Add the dependent repository CRCBS with the command `add add https://github.com/sisl/CRCBS.jl.git`
+Add the dependent repository CRCBS with the command `add https://github.com/sisl/CRCBS.jl.git`
 ```Julia
-pkg> add add https://github.com/sisl/CRCBS.jl.git
+pkg> add https://github.com/sisl/CRCBS.jl.git
 ```
 Add the repository with the command `add https://github.com/sisl/TaskGraphs.jl.git`
 ```Julia


### PR DESCRIPTION
Minor edit in command and instruction